### PR TITLE
Support equal signs inside attribute values

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,9 +144,12 @@ function parseShortcodeAttributes(attributeString) {
   if (attrMatch) {
     attrMatch.map(function(item) {
       var split = item.split("=");
-      var key = split[0].trim();
+      var key = split.shift().trim();
       // Strip surrounding quotes from value, if they exist.
-      var val = split[1].trim().replace(/^"(.*)"$/, "$1");
+      var val = split
+        .join("=")
+        .trim()
+        .replace(/^"(.*)"$/, "$1");
       attributes[key] = val;
     });
   }

--- a/test.js
+++ b/test.js
@@ -115,3 +115,24 @@ test("test multiple block level shortcodes", function(t) {
   testAST(t, {}, markdown, expected);
   t.end();
 });
+
+test("test attributes with equals in value", function(t) {
+  var markdown =
+    'Drum and Bass\n\n[[ Youtube href="https://youtube.com?q=test" ]]';
+  var expected = {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: [{ type: "text", value: "Drum and Bass" }]
+      },
+      {
+        type: "shortcode",
+        identifier: "Youtube",
+        attributes: { href: "https://youtube.com?q=test" }
+      }
+    ]
+  };
+  testAST(t, {}, markdown, expected);
+  t.end();
+});


### PR DESCRIPTION
Allows for attributes to have values that include quotes, for example urls that include search parameters.