### PR TITLE
Add support for using shortcodes inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,50 @@ Running `node example2` yields:
 Example paragraph\n\n{{> MailchimpForm id="chfk2" <}}
 ```
 
+Say `example3.js` looks as follows:
+
+```javascript
+var unified = require('unified');
+var parse = require('remark-parse');
+var shortcodes = require('remark-shortcodes');
+
+var markdown = 'Example paragraph {{> MailchimpForm id="chfk2" <}}'
+
+var tree = unified()
+  .use(parse)
+  // Plugin inserted below, with custom options for start/end blocks.
+  .use(shortcodes, {startBlock: "{{>", endBlock: "<}}", allowInline: true})
+  // Turn off position output for legibility below.
+  .data('settings', {position: false})
+  .parse(markdown);
+
+console.dir(tree, {depth: null});
+```
+
+Running `node example3` yields:
+
+```json
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Example paragraph "
+        },
+        {
+          "type": "shortcode",
+          "identifier": "MailchimpForm",
+          "attributes": { "id": "chfk2" }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## API
 
 ### `remark.use(shortcodes, {options})`
@@ -155,6 +199,7 @@ Where options support the keys:
 
 - `startBlock`: the start block to look for. Default: `[[`.
 - `endBlock`: the end block to look for. Default: `]]`.
+- `allowInline`: allows shortcodes to be used inline. Default: `false`.
 
 NB: Be careful when using custom start/end blocks, your choices
 may clash with other markdown syntax and/or other remark plugins.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ var markdown = 'Example paragraph {{> MailchimpForm id="chfk2" <}}'
 var tree = unified()
   .use(parse)
   // Plugin inserted below, with custom options for start/end blocks.
-  .use(shortcodes, {startBlock: "{{>", endBlock: "<}}", allowInline: true})
+  .use(shortcodes, {startBlock: "{{>", endBlock: "<}}", inlineMode: true})
   // Turn off position output for legibility below.
   .data('settings', {position: false})
   .parse(markdown);
@@ -199,7 +199,7 @@ Where options support the keys:
 
 - `startBlock`: the start block to look for. Default: `[[`.
 - `endBlock`: the end block to look for. Default: `]]`.
-- `allowInline`: allows shortcodes to be used inline. Default: `false`.
+- `inlineMode`: shortcodes will be parsed inline rather than in block mode. Default: `false`.
 
 NB: Be careful when using custom start/end blocks, your choices
 may clash with other markdown syntax and/or other remark plugins.

--- a/index.js
+++ b/index.js
@@ -43,12 +43,12 @@ module.exports = shortcodes;
 function shortcodes(options) {
   var startBlock = (options || {}).startBlock || "[[";
   var endBlock = (options || {}).endBlock || "]]";
-  var allowInline = (options || {}).allowInline || false;
+  var inlineMode = (options || {}).inlineMode || false;
 
   if (isRemarkParser(this.Parser)) {
     var parser = this.Parser.prototype;
-    var tokenizers = allowInline ? parser.inlineTokenizers : parser.blockTokenizers;
-    var methods = allowInline ? parser.inlineMethods : parser.blockMethods;
+    var tokenizers = inlineMode ? parser.inlineTokenizers : parser.blockTokenizers;
+    var methods = inlineMode ? parser.inlineMethods : parser.blockMethods;
 
     tokenizers.shortcode = shortcodeTokenizer;
     methods.splice(methods.indexOf("html"), 0, "shortcode");

--- a/index.js
+++ b/index.js
@@ -43,15 +43,15 @@ module.exports = shortcodes;
 function shortcodes(options) {
   var startBlock = (options || {}).startBlock || "[[";
   var endBlock = (options || {}).endBlock || "]]";
+  var allowInline = (options || {}).allowInline || false;
 
   if (isRemarkParser(this.Parser)) {
     var parser = this.Parser.prototype;
-    parser.blockTokenizers.shortcode = shortcodeTokenizer;
-    parser.blockMethods.splice(
-      parser.blockMethods.indexOf("html"),
-      0,
-      "shortcode"
-    );
+    var tokenizers = allowInline ? parser.inlineTokenizers : parser.blockTokenizers;
+    var methods = allowInline ? parser.inlineMethods : parser.blockMethods;
+
+    tokenizers.shortcode = shortcodeTokenizer;
+    methods.splice(methods.indexOf("html"), 0, "shortcode");
   }
   if (isRemarkCompiler(this.Compiler)) {
     var compiler = this.Compiler.prototype;

--- a/test.js
+++ b/test.js
@@ -68,6 +68,25 @@ test("test block level shortcode without attributes", function(t) {
   t.end();
 });
 
+test("test inline level shortcode without attributes", function(t) {
+  var inputMarkdown = "Drum and Bass [[ Youtube ]]";
+  var outputMarkdown = "Drum and Bass [[ Youtube ]]\n";
+  var ast = {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: [
+          { type: "text", value: "Drum and Bass " },
+          { type: "shortcode", identifier: "Youtube", attributes: {} }
+        ]
+      }
+    ]
+  };
+  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
+  t.end();
+});
+
 test("test block level shortcode with attributes", function(t) {
   var inputMarkdown =
     'Drum and Bass\n\n[[ Youtube id=3 share_code="abc" share-code="def" ]]\n\nTest sentence';
@@ -92,6 +111,38 @@ test("test block level shortcode with attributes", function(t) {
     ]
   };
   tester(t, {}, inputMarkdown, outputMarkdown, ast);
+  t.end();
+});
+
+test("test inline level shortcode with attributes", function(t) {
+  var inputMarkdown =
+    'Drum and Bass [[ Youtube id=3 share_code="abc" share-code="def" ]] Test sentence';
+  var outputMarkdown =
+    'Drum and Bass [[ Youtube id="3" share_code="abc" share-code="def" ]] Test sentence\n';
+  var ast = {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: [
+          {
+            type: "text",
+            value: "Drum and Bass "
+          },
+          {
+            type: "shortcode",
+            identifier: "Youtube",
+            attributes: { id: "3", share_code: "abc", "share-code": "def" }
+          },
+          {
+            type: "text",
+            value: " Test sentence"
+          }
+        ]
+      }      
+    ]
+  };
+  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
   t.end();
 });
 
@@ -128,6 +179,44 @@ test("test block level shortcode with custom start/end blocks", function(t) {
   t.end();
 });
 
+test("test block level shortcode with custom start/end blocks", function(t) {
+  var inputMarkdown =
+    'Drum and Bass {{% Youtube id=3 share-code="abc" %}} Test sentence';
+  var outputMarkdown =
+    'Drum and Bass {{% Youtube id="3" share-code="abc" %}} Test sentence\n';
+  var ast = {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: [
+          {
+            type: "text",
+            value: "Drum and Bass "
+          },
+          {
+            type: "shortcode",
+            identifier: "Youtube",
+            attributes: { id: "3", "share-code": "abc" }
+          },
+          {
+            type: "text",
+            value: " Test sentence"
+          }
+        ]
+      }
+    ]
+  };
+  tester(
+    t,
+    { startBlock: "{{%", endBlock: "%}}", allowInline: true },
+    inputMarkdown,
+    outputMarkdown,
+    ast
+  );
+  t.end();
+});
+
 test("test multiple block level shortcodes", function(t) {
   var inputMarkdown =
     '[[ Youtube id=3 ]]\n\nDrum and Bass\n\n[[ Vimeo id="4" ]]';
@@ -153,6 +242,39 @@ test("test multiple block level shortcodes", function(t) {
     ]
   };
   tester(t, {}, inputMarkdown, outputMarkdown, ast);
+  t.end();
+});
+
+test("test multiple inline level shortcodes", function(t) {
+  var inputMarkdown =
+    '[[ Youtube id=3 ]] Drum and Bass [[ Vimeo id="4" ]]';
+  var outputMarkdown =
+    '[[ Youtube id="3" ]] Drum and Bass [[ Vimeo id="4" ]]\n';
+  var ast = {
+    type: "root",
+    children: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: "shortcode",
+            identifier: "Youtube",
+            attributes: { id: "3" }
+          },
+          {
+            type: "text",
+            value: " Drum and Bass "
+          },
+          {
+            type: "shortcode",
+            identifier: "Vimeo",
+            attributes: { id: "4" }
+          }
+        ]
+      }
+    ]
+  };
+  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
   t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -83,7 +83,7 @@ test("test inline level shortcode without attributes", function(t) {
       }
     ]
   };
-  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
+  tester(t, { inlineMode: true }, inputMarkdown, outputMarkdown, ast);
   t.end();
 });
 
@@ -139,10 +139,10 @@ test("test inline level shortcode with attributes", function(t) {
             value: " Test sentence"
           }
         ]
-      }      
+      }
     ]
   };
-  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
+  tester(t, { inlineMode: true }, inputMarkdown, outputMarkdown, ast);
   t.end();
 });
 
@@ -209,7 +209,7 @@ test("test block level shortcode with custom start/end blocks", function(t) {
   };
   tester(
     t,
-    { startBlock: "{{%", endBlock: "%}}", allowInline: true },
+    { startBlock: "{{%", endBlock: "%}}", inlineMode: true },
     inputMarkdown,
     outputMarkdown,
     ast
@@ -274,7 +274,7 @@ test("test multiple inline level shortcodes", function(t) {
       }
     ]
   };
-  tester(t, { allowInline: true }, inputMarkdown, outputMarkdown, ast);
+  tester(t, { inlineMode: true }, inputMarkdown, outputMarkdown, ast);
   t.end();
 });
 


### PR DESCRIPTION
This resolves issue #5 and introduces a new option to allow shortcodes to be used inline without breaking the AST structure of using shortcodes within blocks. Happy to iterate!