### PR TITLE
Add support for attributes with no value

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,19 +158,20 @@ function parseShortcodeAttributes(attributeString) {
   var attributes = {};
   var attrMatch = attributeString
     .trim()
-    .match(/(?:[\w-]*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^}\s]+))/g);
+    .matchAll(/([\w-]+)(?:=)?((?:"[^"]*")|(?:'[^']*')|[^\s]+)?/g);
 
   if (attrMatch) {
-    attrMatch.map(function(item) {
-      var split = item.split("=");
-      var key = split.shift().trim();
-      // Strip surrounding quotes from value, if they exist.
-      var val = split
-        .join("=")
-        .trim()
-        .replace(/^"(.*)"$/, "$1");
+    for (let match of attrMatch) {
+      var key = match[1];
+
+      if (match[2] !== undefined) {
+        var val = match[2].trim().replace(/^"(.*)"$/, "$1");
+      } else {
+        var val = undefined;
+      }
+
       attributes[key] = val;
-    });
+    }
   }
   return attributes;
 }


### PR DESCRIPTION
Hi!

This add support for attributes with no values. We use it at [@gamedevalliance](https://github.com/gamedevalliance) for a video shortcode which work for example like this:

`[[Video src="/videos/pico-8/jelpi.mp4" autoplay muted loop controls]]`

The code works perfectly but was written quite hastily, if the proposition is accepted, I can rewrite it in a better style if needed. My version use `String.matchAll` which bump the node requirement to Node 12.0.0 (the current active LTS support this)